### PR TITLE
feat: add the first profile management slice

### DIFF
--- a/docs/plans/2026-03-12-profile-management.md
+++ b/docs/plans/2026-03-12-profile-management.md
@@ -1,0 +1,199 @@
+# Profile Management Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deliver the first usable Profile management slice for issue `#3` with create/edit/delete/duplicate actions, per-profile proxy settings, and local persistence across restarts.
+
+**Architecture:** Start with a `localStorage`-backed JSON store behind small `loadProfiles` / `saveProfiles` helpers so the UI is fully testable in Vitest and easy to swap to a Tauri JSON or SQLite backend later. Move the Profiles screen into its own feature component that owns form state, persists profile arrays, and renders a list of profile cards with actions.
+
+**Tech Stack:** React 19, React Router, Vitest, Testing Library, TypeScript
+
+### Task 1: Add the profile data model and storage adapter
+
+**Files:**
+- Create: `src/features/profiles/storage.ts`
+- Create: `src/features/profiles/storage.test.ts`
+- Modify: `src/features/profiles/index.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it("returns an empty list when storage payload is invalid", () => {
+  const storage = createMemoryStorage({
+    "fingerprint-browser.profiles.v1": "{bad json",
+  })
+
+  expect(loadProfiles(storage)).toEqual([])
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/features/profiles/storage.test.ts`
+Expected: FAIL because `loadProfiles` is not implemented yet.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export function loadProfiles(storage: StorageLike = window.localStorage) {
+  const raw = storage.getItem(PROFILE_STORAGE_KEY)
+  if (!raw) return []
+
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return []
+  }
+}
+```
+
+Add the profile types, defaults, save helper, and duplicate helper used by the page.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/features/profiles/storage.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/profiles/index.ts src/features/profiles/storage.ts src/features/profiles/storage.test.ts
+git commit -m "feat: add profile storage helpers"
+```
+
+### Task 2: Build the interactive Profiles page
+
+**Files:**
+- Create: `src/features/profiles/ProfilesPage.tsx`
+- Create: `src/features/profiles/ProfilesPage.test.tsx`
+- Modify: `src/App.tsx`
+- Modify: `src/App.css`
+
+**Step 1: Write the failing test**
+
+```ts
+it("creates a profile with independent proxy settings and persists it", async () => {
+  render(<ProfilesPage />)
+  await user.type(screen.getByLabelText(/profile name/i), "Shop A")
+  await user.type(screen.getByLabelText(/proxy host/i), "127.0.0.1")
+  await user.type(screen.getByLabelText(/proxy port/i), "8899")
+  await user.click(screen.getByRole("button", { name: /create profile/i }))
+
+  expect(screen.getByText("Shop A")).toBeInTheDocument()
+  expect(screen.getByText(/http:\/\/127.0.0.1:8899/i)).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/features/profiles/ProfilesPage.test.tsx`
+Expected: FAIL because the interactive Profiles page does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+const [profiles, setProfiles] = useState(() => loadProfiles())
+const [draft, setDraft] = useState(createEmptyProfileDraft())
+
+function handleSubmit(event: FormEvent) {
+  event.preventDefault()
+  const nextProfiles = [...profiles, buildProfile(draft)]
+  setProfiles(nextProfiles)
+  saveProfiles(nextProfiles)
+}
+```
+
+Add edit, duplicate, and delete actions plus a persisted list view.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/features/profiles/ProfilesPage.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/profiles/ProfilesPage.tsx src/features/profiles/ProfilesPage.test.tsx src/App.tsx src/App.css
+git commit -m "feat: add profile management page"
+```
+
+### Task 3: Cover persistence, edit, duplicate, and delete behaviors
+
+**Files:**
+- Modify: `src/features/profiles/ProfilesPage.test.tsx`
+- Modify: `src/features/profiles/ProfilesPage.tsx`
+
+**Step 1: Write the failing test**
+
+```ts
+it("hydrates persisted profiles and supports edit, duplicate, and delete", async () => {
+  seedProfiles([existingProfile])
+  render(<ProfilesPage />)
+
+  expect(screen.getByText(existingProfile.name)).toBeInTheDocument()
+  await user.click(screen.getByRole("button", { name: /duplicate seeded profile/i }))
+  await user.click(screen.getByRole("button", { name: /edit seeded profile/i }))
+  await user.clear(screen.getByLabelText(/proxy host/i))
+  await user.type(screen.getByLabelText(/proxy host/i), "proxy.example.com")
+  await user.click(screen.getByRole("button", { name: /save changes/i }))
+
+  expect(screen.getByText(/proxy.example.com/i)).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/features/profiles/ProfilesPage.test.tsx`
+Expected: FAIL because not all list actions are implemented yet.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+function handleDuplicate(profileId: string) { ... }
+function handleEdit(profileId: string) { ... }
+function handleDelete(profileId: string) { ... }
+```
+
+Keep all mutations funneled through one persistence helper so `localStorage` always matches the rendered list.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/features/profiles/ProfilesPage.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/profiles/ProfilesPage.tsx src/features/profiles/ProfilesPage.test.tsx
+git commit -m "test: cover profile list actions"
+```
+
+### Task 4: Verify and publish the issue #3 slice
+
+**Files:**
+- Create: `docs/plans/2026-03-12-profile-management.md`
+- Modify: `package-lock.json` (only if dependency metadata changes)
+
+**Step 1: Run the profile feature tests**
+
+Run: `npm test -- src/features/profiles/storage.test.ts src/features/profiles/ProfilesPage.test.tsx`
+Expected: PASS
+
+**Step 2: Run the full project tests**
+
+Run: `npm test`
+Expected: PASS
+
+**Step 3: Run static verification**
+
+Run: `npm run lint`
+Expected: PASS
+
+**Step 4: Run the production build**
+
+Run: `npm run build`
+Expected: PASS
+
+**Step 5: Publish**
+
+Create a new GitHub branch from `feat/issue-2-project-skeleton`, push the changed files with GitHub MCP, open a stacked PR referencing `#3`, and note that persistence currently uses the frontend JSON/localStorage adapter so the next iteration can swap in a Tauri-backed store.

--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,12 @@ a {
   font: inherit;
 }
 
+input,
+select,
+textarea {
+  font: inherit;
+}
+
 .app-shell {
   min-height: 100vh;
   display: grid;
@@ -109,6 +115,12 @@ a {
   border: 1px solid rgba(95, 208, 255, 0.35);
 }
 
+.status-pill--muted {
+  background: rgba(255, 255, 255, 0.06);
+  color: #dbe3ff;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
 .overview-grid,
 .panel-list {
   display: grid;
@@ -147,6 +159,105 @@ a {
   padding-left: 1.2rem;
 }
 
+.profiles-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 380px) minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.profile-form {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.field,
+.field-row {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.field-row {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.field span {
+  color: #dbe3ff;
+  font-size: 0.92rem;
+}
+
+.field input,
+.field select,
+.field textarea {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  background: rgba(8, 11, 20, 0.72);
+  color: #f6f7fb;
+  padding: 0.8rem 0.9rem;
+}
+
+.primary-button,
+.secondary-button {
+  border: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: 120ms ease-in-out;
+}
+
+.primary-button {
+  padding: 0.85rem 1rem;
+  color: #08101f;
+  background: linear-gradient(135deg, #8ce3ff, #8ea4ff);
+  font-weight: 700;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  filter: brightness(1.05);
+}
+
+.profile-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-card__header,
+.profile-card__actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.profile-card__actions {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.secondary-button {
+  padding: 0.65rem 0.9rem;
+  color: #dbe3ff;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  background: rgba(142, 164, 255, 0.18);
+  border-color: rgba(142, 164, 255, 0.32);
+}
+
+.secondary-button--danger:hover,
+.secondary-button--danger:focus-visible {
+  background: rgba(255, 107, 107, 0.18);
+  border-color: rgba(255, 107, 107, 0.38);
+}
+
 @media (max-width: 960px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -158,7 +269,9 @@ a {
   }
 
   .overview-grid,
-  .panel-list {
+  .panel-list,
+  .profiles-layout,
+  .field-row {
     grid-template-columns: 1fr;
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { HashRouter, NavLink, Route, Routes } from "react-router-dom"
 import { automationMilestones } from "./features/automation"
-import { profileModelItems, profileNextStep } from "./features/profiles"
+import { ProfilesPage } from "./features/profiles/ProfilesPage"
 import { runtimeDefaults, runtimeDiagnostics } from "./features/runtime"
 import { loadDesktopOverview, type DesktopOverview } from "./lib/desktop"
 import "./App.css"
@@ -64,38 +64,6 @@ function DashboardPage({ overview }: { overview: DesktopOverview | null }) {
           value={String(automationMilestones.length)}
           helper="Planned: Playwright, CreepJS, and BrowserLeaks validation flows."
         />
-      </div>
-    </section>
-  )
-}
-
-function ProfilesPage() {
-  return (
-    <section className="page-shell">
-      <header className="page-shell__header">
-        <div>
-          <p className="eyebrow">Identity workspace</p>
-          <h1>Profiles</h1>
-          <p>
-            Create, organize, and launch isolated browser profiles with their own
-            proxy and fingerprint settings.
-          </p>
-        </div>
-      </header>
-
-      <div className="panel-list">
-        <article className="panel-card">
-          <h2>Profile model</h2>
-          <ul>
-            {profileModelItems.map((item) => (
-              <li key={item}>{item}</li>
-            ))}
-          </ul>
-        </article>
-        <article className="panel-card">
-          <h2>Next step</h2>
-          <p>{profileNextStep}</p>
-        </article>
       </div>
     </section>
   )

--- a/src/features/profiles/ProfilesPage.test.tsx
+++ b/src/features/profiles/ProfilesPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  PROFILE_STORAGE_KEY,
+  createEmptyProfileDraft,
+  createProfileFromDraft,
+  saveProfiles,
+} from "./storage"
+import { ProfilesPage } from "./ProfilesPage"
+
+describe("ProfilesPage", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it("creates a profile with independent proxy settings and persists it", async () => {
+    const user = userEvent.setup()
+
+    render(<ProfilesPage />)
+
+    await user.type(screen.getByLabelText(/profile name/i), "Shop A")
+    await user.clear(screen.getByLabelText(/group/i))
+    await user.type(screen.getByLabelText(/group/i), "Retail")
+    await user.type(screen.getByLabelText(/tags/i), "checkout, cn")
+    await user.type(screen.getByLabelText(/proxy host/i), "127.0.0.1")
+    await user.type(screen.getByLabelText(/proxy port/i), "8899")
+    await user.click(screen.getByRole("button", { name: /create profile/i }))
+
+    expect(screen.getByText("Shop A")).toBeInTheDocument()
+    expect(screen.getByText("Retail")).toBeInTheDocument()
+    expect(screen.getByText(/http:\/\/127\.0\.0\.1:8899/i)).toBeInTheDocument()
+    expect(JSON.parse(window.localStorage.getItem(PROFILE_STORAGE_KEY) ?? "[]")).toHaveLength(1)
+  })
+
+  it("hydrates persisted profiles and supports edit, duplicate, and delete", async () => {
+    const user = userEvent.setup()
+    const seededProfile = createProfileFromDraft({
+      ...createEmptyProfileDraft(),
+      name: "Seeded profile",
+      group: "Operations",
+      proxy: {
+        type: "socks5",
+        host: "seed.proxy",
+        port: "9000",
+        username: "bot",
+        password: "secret",
+      },
+      fingerprint: {
+        ...createEmptyProfileDraft().fingerprint,
+        timezone: "Europe/London",
+        locale: "en-GB",
+      },
+    })
+
+    saveProfiles([seededProfile])
+
+    render(<ProfilesPage />)
+
+    expect(screen.getByText("Seeded profile")).toBeInTheDocument()
+    expect(screen.getByText(/socks5:\/\/seed\.proxy:9000/i)).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: /duplicate seeded profile/i }),
+    )
+    expect(screen.getByText("Seeded profile (copy)")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Edit Seeded profile" }))
+    await user.clear(screen.getByLabelText(/proxy host/i))
+    await user.type(screen.getByLabelText(/proxy host/i), "proxy.example.com")
+    await user.click(screen.getByRole("button", { name: /save changes/i }))
+
+    expect(
+      screen.getByText(/socks5:\/\/proxy\.example\.com:9000/i),
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: /delete seeded profile \(copy\)/i }),
+    )
+    expect(screen.queryByText("Seeded profile (copy)")).not.toBeInTheDocument()
+    expect(JSON.parse(window.localStorage.getItem(PROFILE_STORAGE_KEY) ?? "[]")).toHaveLength(1)
+  })
+})

--- a/src/features/profiles/ProfilesPage.tsx
+++ b/src/features/profiles/ProfilesPage.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useMemo, useState } from "react"
+import type { FormEvent } from "react"
+import {
+  createEmptyProfileDraft,
+  createProfileFromDraft,
+  duplicateProfile,
+  loadProfiles,
+  saveProfiles,
+  toProfileDraft,
+  updateProfileFromDraft,
+  type BrowserProfile,
+  type ProfileDraft,
+} from "./storage"
+
+type ProfileFormState = ProfileDraft & {
+  tagsInput: string
+}
+
+function createEmptyFormState(): ProfileFormState {
+  const draft = createEmptyProfileDraft()
+
+  return {
+    ...draft,
+    tagsInput: "",
+  }
+}
+
+function buildDraft(formState: ProfileFormState): ProfileDraft {
+  return {
+    ...formState,
+    tags: formState.tagsInput
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+  }
+}
+
+function formatProxyLabel(draft: ProfileDraft) {
+  if (!draft.proxy.host || !draft.proxy.port) {
+    return "No proxy configured"
+  }
+
+  return `${draft.proxy.type}://${draft.proxy.host}:${draft.proxy.port}`
+}
+
+export function ProfilesPage() {
+  const [profiles, setProfiles] = useState(() => loadProfiles())
+  const [editingProfileId, setEditingProfileId] = useState<string | null>(null)
+  const [formState, setFormState] = useState(createEmptyFormState)
+
+  useEffect(() => {
+    saveProfiles(profiles)
+  }, [profiles])
+
+  const profileCountLabel = useMemo(
+    () => `${profiles.length} saved profile${profiles.length === 1 ? "" : "s"}`,
+    [profiles],
+  )
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const nextDraft = buildDraft(formState)
+    const nextProfiles = editingProfileId
+      ? profiles.map((profile) =>
+          profile.id === editingProfileId
+            ? updateProfileFromDraft(profile, nextDraft)
+            : profile,
+        )
+      : [...profiles, createProfileFromDraft(nextDraft)]
+
+    setProfiles(nextProfiles)
+    setEditingProfileId(null)
+    setFormState(createEmptyFormState())
+  }
+
+  function handleEdit(profile: BrowserProfile) {
+    setEditingProfileId(profile.id)
+    setFormState({
+      ...toProfileDraft(profile),
+      tagsInput: profile.tags.join(", "),
+    })
+  }
+
+  function handleDuplicate(profile: BrowserProfile) {
+    setProfiles((current) => [...current, duplicateProfile(profile)])
+  }
+
+  function handleDelete(profileId: string) {
+    setProfiles((current) => current.filter((profile) => profile.id !== profileId))
+
+    if (editingProfileId === profileId) {
+      setEditingProfileId(null)
+      setFormState(createEmptyFormState())
+    }
+  }
+
+  return (
+    <section className="page-shell">
+      <header className="page-shell__header">
+        <div>
+          <p className="eyebrow">Identity workspace</p>
+          <h1>Profiles</h1>
+          <p>
+            Create, organize, and launch isolated browser profiles with their own
+            proxy and fingerprint settings.
+          </p>
+        </div>
+        <span className="status-pill">{profileCountLabel}</span>
+      </header>
+
+      <div className="profiles-layout">
+        <article className="panel-card">
+          <h2>{editingProfileId ? "Edit profile" : "Create profile"}</h2>
+          <form className="profile-form" onSubmit={handleSubmit}>
+            <label className="field">
+              <span>Profile name</span>
+              <input
+                value={formState.name}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, name: event.target.value }))
+                }
+              />
+            </label>
+
+            <label className="field">
+              <span>Group</span>
+              <input
+                value={formState.group}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, group: event.target.value }))
+                }
+              />
+            </label>
+
+            <label className="field">
+              <span>Tags</span>
+              <input
+                value={formState.tagsInput}
+                onChange={(event) =>
+                  setFormState((current) => ({ ...current, tagsInput: event.target.value }))
+                }
+              />
+            </label>
+
+            <div className="field-row">
+              <label className="field">
+                <span>Proxy type</span>
+                <select
+                  value={formState.proxy.type}
+                  onChange={(event) =>
+                    setFormState((current) => ({
+                      ...current,
+                      proxy: {
+                        ...current.proxy,
+                        type: event.target.value as ProfileDraft["proxy"]["type"],
+                      },
+                    }))
+                  }
+                >
+                  <option value="http">HTTP</option>
+                  <option value="socks5">SOCKS5</option>
+                </select>
+              </label>
+
+              <label className="field">
+                <span>Proxy host</span>
+                <input
+                  value={formState.proxy.host}
+                  onChange={(event) =>
+                    setFormState((current) => ({
+                      ...current,
+                      proxy: { ...current.proxy, host: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+
+              <label className="field">
+                <span>Proxy port</span>
+                <input
+                  value={formState.proxy.port}
+                  onChange={(event) =>
+                    setFormState((current) => ({
+                      ...current,
+                      proxy: { ...current.proxy, port: event.target.value },
+                    }))
+                  }
+                />
+              </label>
+            </div>
+
+            <button className="primary-button" type="submit">
+              {editingProfileId ? "Save changes" : "Create profile"}
+            </button>
+          </form>
+        </article>
+
+        <div className="profile-list">
+          {profiles.map((profile) => (
+            <article className="panel-card profile-card" key={profile.id}>
+              <div className="profile-card__header">
+                <div>
+                  <h2>{profile.name}</h2>
+                  <p>{profile.group}</p>
+                </div>
+                <span className="status-pill status-pill--muted">
+                  {formatProxyLabel(profile)}
+                </span>
+              </div>
+              <p>
+                {profile.tags.length > 0 ? profile.tags.join(", ") : "No tags yet"}
+              </p>
+              <div className="profile-card__actions">
+                <button
+                  className="secondary-button"
+                  type="button"
+                  aria-label={`Edit ${profile.name}`}
+                  onClick={() => handleEdit(profile)}
+                >
+                  Edit
+                </button>
+                <button
+                  className="secondary-button"
+                  type="button"
+                  aria-label={`Duplicate ${profile.name}`}
+                  onClick={() => handleDuplicate(profile)}
+                >
+                  Duplicate
+                </button>
+                <button
+                  className="secondary-button secondary-button--danger"
+                  type="button"
+                  aria-label={`Delete ${profile.name}`}
+                  onClick={() => handleDelete(profile.id)}
+                >
+                  Delete
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/features/profiles/index.ts
+++ b/src/features/profiles/index.ts
@@ -5,4 +5,17 @@ export const profileModelItems = [
 ]
 
 export const profileNextStep =
-  "Wire this page to persistent storage so profiles survive restarts and can be reused by the runtime adapter."
+  "Profiles in this MVP persist in local storage today and can later move behind a Tauri-backed JSON or SQLite store."
+
+export {
+  PROFILE_STORAGE_KEY,
+  createEmptyProfileDraft,
+  createProfileFromDraft,
+  duplicateProfile,
+  loadProfiles,
+  saveProfiles,
+  toProfileDraft,
+  updateProfileFromDraft,
+  type BrowserProfile,
+  type ProfileDraft,
+} from "./storage"

--- a/src/features/profiles/storage.test.ts
+++ b/src/features/profiles/storage.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import {
+  PROFILE_STORAGE_KEY,
+  createEmptyProfileDraft,
+  duplicateProfile,
+  loadProfiles,
+  saveProfiles,
+} from "./storage"
+
+function createMemoryStorage(seed: Record<string, string> = {}): Storage {
+  const store = new Map(Object.entries(seed))
+
+  return {
+    get length() {
+      return store.size
+    },
+    clear() {
+      store.clear()
+    },
+    getItem(key) {
+      return store.get(key) ?? null
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    removeItem(key) {
+      store.delete(key)
+    },
+    setItem(key, value) {
+      store.set(key, value)
+    },
+  }
+}
+
+describe("profile storage", () => {
+  it("returns an empty list when storage payload is invalid", () => {
+    const storage = createMemoryStorage({
+      [PROFILE_STORAGE_KEY]: "{bad json",
+    })
+
+    expect(loadProfiles(storage)).toEqual([])
+  })
+
+  it("saves, loads, and duplicates profiles with independent ids", () => {
+    const storage = createMemoryStorage()
+    const original = {
+      ...createEmptyProfileDraft(),
+      id: "profile-1",
+      name: "Shop A",
+      group: "Retail",
+      tags: ["checkout"],
+      proxy: {
+        type: "http" as const,
+        host: "127.0.0.1",
+        port: "8899",
+        username: "",
+        password: "",
+      },
+      fingerprint: {
+        timezone: "Asia/Shanghai",
+        locale: "zh-CN",
+        geolocationPolicy: "prompt" as const,
+        screen: "1920x1080",
+        memory: "8",
+        hardwareConcurrency: "8",
+      },
+      createdAt: "2026-03-12T00:00:00.000Z",
+      updatedAt: "2026-03-12T00:00:00.000Z",
+    }
+
+    saveProfiles([original], storage)
+    const copy = duplicateProfile(original)
+
+    expect(loadProfiles(storage)).toEqual([original])
+    expect(copy.id).not.toBe(original.id)
+    expect(copy.name).toBe("Shop A (copy)")
+    expect(copy.proxy).toEqual(original.proxy)
+  })
+})

--- a/src/features/profiles/storage.ts
+++ b/src/features/profiles/storage.ts
@@ -1,0 +1,145 @@
+export const PROFILE_STORAGE_KEY = "fingerprint-browser.profiles.v1"
+
+export type ProxyType = "http" | "socks5"
+export type GeolocationPolicy = "prompt" | "allow" | "block"
+
+export type ProfileProxy = {
+  type: ProxyType
+  host: string
+  port: string
+  username: string
+  password: string
+}
+
+export type ProfileFingerprint = {
+  timezone: string
+  locale: string
+  geolocationPolicy: GeolocationPolicy
+  screen: string
+  memory: string
+  hardwareConcurrency: string
+}
+
+export type ProfileDraft = {
+  name: string
+  group: string
+  tags: string[]
+  notes: string
+  browserEngine: string
+  browserVersion: string
+  proxy: ProfileProxy
+  fingerprint: ProfileFingerprint
+}
+
+export type BrowserProfile = ProfileDraft & {
+  id: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type StorageLike = Pick<Storage, "getItem" | "setItem">
+
+export function createEmptyProfileDraft(): ProfileDraft {
+  return {
+    name: "",
+    group: "Default",
+    tags: [],
+    notes: "",
+    browserEngine: "Chromium",
+    browserVersion: "stable",
+    proxy: {
+      type: "http",
+      host: "",
+      port: "",
+      username: "",
+      password: "",
+    },
+    fingerprint: {
+      timezone: "UTC",
+      locale: "en-US",
+      geolocationPolicy: "prompt",
+      screen: "1920x1080",
+      memory: "8",
+      hardwareConcurrency: "8",
+    },
+  }
+}
+
+export function createProfileFromDraft(draft: ProfileDraft): BrowserProfile {
+  const timestamp = new Date().toISOString()
+
+  return {
+    ...draft,
+    id: createProfileId(),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+}
+
+export function toProfileDraft(profile: BrowserProfile): ProfileDraft {
+  return {
+    name: profile.name,
+    group: profile.group,
+    tags: profile.tags,
+    notes: profile.notes,
+    browserEngine: profile.browserEngine,
+    browserVersion: profile.browserVersion,
+    proxy: { ...profile.proxy },
+    fingerprint: { ...profile.fingerprint },
+  }
+}
+
+export function updateProfileFromDraft(
+  profile: BrowserProfile,
+  draft: ProfileDraft,
+): BrowserProfile {
+  return {
+    ...profile,
+    ...draft,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+export function duplicateProfile(profile: BrowserProfile): BrowserProfile {
+  const timestamp = new Date().toISOString()
+
+  return {
+    ...profile,
+    id: createProfileId(),
+    name: `${profile.name} (copy)`,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+}
+
+export function loadProfiles(
+  storage: StorageLike = window.localStorage,
+): BrowserProfile[] {
+  const raw = storage.getItem(PROFILE_STORAGE_KEY)
+
+  if (!raw) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+export function saveProfiles(
+  profiles: BrowserProfile[],
+  storage: StorageLike = window.localStorage,
+) {
+  storage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(profiles))
+}
+
+function createProfileId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+
+  return `profile-${Math.random().toString(36).slice(2, 10)}`
+}


### PR DESCRIPTION
## Summary
- add a `localStorage`-backed profile store with typed helpers for create/load/save/update/duplicate
- replace the placeholder Profiles screen with a working manager UI for create/edit/delete/duplicate and per-profile proxy settings
- add plan and regression tests covering persistence, hydration, and list actions for issue #3

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- persistence is intentionally implemented as a frontend JSON/localStorage adapter in this slice so it is fully testable now and can be swapped to a Tauri JSON or SQLite backend later
- this PR is stacked on top of `#8` (`feat/issue-2-project-skeleton`)

Refs #3