### PR TITLE
docs: add MVP product and architecture baseline

### DIFF
--- a/docs/architecture/runtime-contract.md
+++ b/docs/architecture/runtime-contract.md
@@ -1,0 +1,216 @@
+# Runtime Contract
+
+> Last updated: 2026-03-13
+
+## 1. 文档目标
+
+定义 Manager App、Runtime Adapter 与 Native Runtime 之间的稳定契约，使上层 UI 不依赖具体浏览器实现，同时为后续 Tauri / Rust / Chromium 接入提供明确边界。
+
+## 2. 设计原则
+
+- **稳定 contract，高频替换实现**
+- **序列化优先**：接口尽量使用可 JSON 序列化的数据结构
+- **纯函数优先**：Runtime Adapter 尽量保持纯逻辑，方便测试
+- **状态与执行分离**：Manager 维护业务状态；Native Runtime 负责真实执行
+
+## 3. 边界划分
+
+### Manager App 负责
+- 读取和维护 `BrowserProfile`
+- 发起“启动 / 停止 / 重启”意图
+- 展示运行状态和错误信息
+- 持久化 profile 和轻量运行态
+
+### Runtime Adapter 负责
+- 将 `BrowserProfile` 转换为 `FingerprintConfig`
+- 生成面向具体浏览器引擎的 `LaunchPlan`
+- 约束不同 runtime 的输入输出结构
+
+### Native Runtime 负责
+- 启动 / 停止真实浏览器进程
+- 管理调试端口、数据目录、进程句柄
+- 返回真实连接信息与错误
+
+## 4. 核心类型
+
+以下类型为建议 contract，作为 issue `#5` 及后续 native runtime 的统一依据。
+
+```ts
+export type WebRtcPolicy = "default" | "proxy-only" | "disabled"
+
+export type FingerprintConfig = {
+  userAgent: string
+  language: string
+  timezone: string
+  resolution: {
+    width: number
+    height: number
+  }
+  memory: number
+  hardwareConcurrency: number
+  geolocationPolicy: "prompt" | "allow" | "block"
+  webrtcPolicy: WebRtcPolicy
+}
+
+export type RuntimeLaunchRequest = {
+  profileId: string
+  profileName: string
+  browserEngine: string
+  browserVersion: string
+  debugPort: number
+  proxy?: {
+    server: string
+    username?: string
+    password?: string
+  }
+  fingerprint: FingerprintConfig
+}
+
+export type RuntimeLaunchPlan = {
+  adapterId: string
+  browserEngine: string
+  launchArgs: string[]
+  env: Record<string, string>
+  fingerprint: FingerprintConfig
+  metadata: {
+    wsPathHint?: string
+    profileDataDir?: string
+  }
+}
+
+export type RuntimeProcessHandle = {
+  instanceId: string
+  profileId: string
+  status: "running" | "stopped" | "error"
+  processId?: number
+  debugPort: number
+  wsEndpoint?: string
+  startedAt: string
+  updatedAt: string
+  lastError?: string
+}
+
+export interface RuntimeAdapter {
+  id: string
+  supports(engine: string): boolean
+  prepareLaunch(request: RuntimeLaunchRequest): RuntimeLaunchPlan
+}
+```
+
+## 5. 推荐的调用链
+
+### 启动流程
+1. Manager 从 `BrowserProfile` 读取配置
+2. Lifecycle Manager 分配 `debugPort`
+3. Runtime Adapter 生成 `RuntimeLaunchPlan`
+4. Native Runtime 执行 `RuntimeLaunchPlan`
+5. Native Runtime 返回 `RuntimeProcessHandle`
+6. Manager 更新 UI 状态与可连接信息
+
+### 停止流程
+1. Manager 发出 stop 请求
+2. Native Runtime 停止真实进程
+3. Lifecycle Manager 更新状态、日志和锁
+
+### 重启流程
+1. Manager 发出 restart 请求
+2. Native Runtime 停止旧进程
+3. 复用或重新生成启动计划
+4. 返回新的 process handle / ws endpoint
+
+## 6. Chromium 适配器输出约定
+
+Chromium Runtime Adapter 至少需要输出以下参数类别：
+
+- `--remote-debugging-port=<port>`
+- `--window-size=<width>,<height>`
+- `--lang=<locale>`
+- `--user-agent=<ua>`（如有配置）
+- `--proxy-server=<scheme://host:port>`（如有代理）
+
+可选参数：
+
+- `--disable-webrtc`
+- `--force-webrtc-ip-handling-policy=disable_non_proxied_udp`
+- profile data dir
+- headless / headed 策略
+
+## 7. Playwright / CDP 合同
+
+当前 contract 的目标不是立刻保证真实可连，而是先稳定字段定义。
+
+Manager 至少需要能展示：
+
+- `debugPort`
+- `wsEndpoint`
+- `adapterId`
+- 关键启动参数摘要
+
+Native Runtime 接入后，需要满足：
+
+- `chromium.connectOverCDP()` 可使用真实 endpoint 或 port
+- 如果浏览器尚未准备好，返回明确错误而不是静默失败
+
+## 8. 错误模型
+
+建议使用结构化错误：
+
+```ts
+export type RuntimeErrorCode =
+  | "PROFILE_ALREADY_RUNNING"
+  | "PORT_ALLOCATION_FAILED"
+  | "ADAPTER_NOT_SUPPORTED"
+  | "RUNTIME_LAUNCH_FAILED"
+  | "RUNTIME_STOP_FAILED"
+  | "WS_ENDPOINT_UNAVAILABLE"
+
+export type RuntimeError = {
+  code: RuntimeErrorCode
+  message: string
+  detail?: string
+  at: string
+}
+```
+
+要求：
+
+- UI 展示友好消息
+- 日志保存原始 detail
+- 同一错误码可用于自动化重试和问题分类
+
+## 9. 兼容当前实现的迁移路径
+
+截至 2026-03-13，当前主线中：
+
+- `runtime/manager.ts` 已负责 lifecycle 抽象
+- `wsEndpoint` 仍是前端拼接的合同面
+- `sessionStorage` 仍是运行态临时存储
+
+迁移建议：
+
+### Phase 1
+- 落地纯 TypeScript `RuntimeAdapter`
+- 在 UI 中展示 adapter 输出摘要
+
+### Phase 2
+- 通过 Tauri command 调用原生 launcher
+- 用真实返回值替换当前 session-backed `BrowserInstance`
+
+### Phase 3
+- 接入 Playwright 真连接
+- 增加运行时错误通道和日志面板
+
+## 10. 验收标准
+
+Runtime contract 被认为成立，至少需要满足：
+
+- `BrowserProfile -> FingerprintConfig` 转换规则明确
+- `FingerprintConfig -> RuntimeLaunchPlan` 输出可测试
+- Manager 不依赖具体浏览器启动实现
+- Native Runtime 可在不改 UI 的前提下接入
+
+## 11. 配套文档
+
+- `docs/product/mvp-prd.md`
+- `docs/architecture/system-design.md`
+- `docs/plans/2026-03-12-runtime-adapter.md`

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -1,0 +1,224 @@
+# fingerprint-browser System Design
+
+> Last updated: 2026-03-13
+
+## 1. 设计目标
+
+本系统采用“Manager App + Runtime Adapter + Native Runtime”三层结构，目标是在不锁死底层实现的前提下，先把上层控制面与领域模型做稳定。
+
+设计重点：
+
+- UI 与真实浏览器进程解耦
+- 先通过纯 TypeScript 逻辑验证领域模型
+- 后续可平滑替换为 Tauri / Rust / Chromium 实现
+
+## 2. 总体架构
+
+```text
+┌──────────────────────────────┐
+│ Manager App (React / Tauri)  │
+│ - Dashboard                  │
+│ - Profiles                   │
+│ - Settings                   │
+└──────────────┬───────────────┘
+               │
+               │ uses
+               ▼
+┌──────────────────────────────┐
+│ Application Services         │
+│ - Profile Storage Adapter    │
+│ - Instance Lifecycle Manager │
+│ - Runtime Adapter            │
+│ - Automation Bridge          │
+└──────────────┬───────────────┘
+               │
+               │ executes / resolves
+               ▼
+┌──────────────────────────────┐
+│ Native Runtime (planned)     │
+│ - Chromium launcher          │
+│ - Process supervisor         │
+│ - CDP / Playwright bridge    │
+│ - Runtime logs               │
+└──────────────────────────────┘
+```
+
+## 3. 当前代码结构映射
+
+### 前端入口
+- `src/App.tsx`
+- `src/App.css`
+
+### Desktop bridge
+- `src/lib/desktop.ts`
+
+### Profile 模块
+- `src/features/profiles/storage.ts`
+- `src/features/profiles/ProfilesPage.tsx`
+
+### Runtime 模块
+- `src/features/runtime/manager.ts`
+- `src/features/runtime/index.ts`
+
+### Automation 模块
+- `src/features/automation/index.ts`
+
+### Native Desktop Host
+- `src-tauri/`
+
+## 4. 核心模块职责
+
+### 4.1 Manager App
+
+负责用户交互、页面编排、配置录入和运行状态可视化。
+
+不负责：
+- 直接拼接复杂浏览器启动参数
+- 直接管理真实浏览器进程生命周期
+- 直接实现检测逻辑细节
+
+### 4.2 Profile Storage Adapter
+
+负责 Profile 数据的读写、默认值填充、兼容旧数据。
+
+当前实现：
+- `localStorage` JSON 持久化
+
+后续目标：
+- 切换到 Tauri 文件存储或 SQLite
+
+### 4.3 Instance Lifecycle Manager
+
+负责实例的抽象生命周期：
+
+- 启动 / 停止 / 重启
+- 调试端口分配
+- profile lock
+- 运行日志摘要
+- UI 展示所需的轻量状态
+
+当前实现：
+- `sessionStorage` 模拟运行态
+
+后续目标：
+- 替换为真实浏览器守护进程与 process handle
+
+### 4.4 Runtime Adapter
+
+负责把 profile 转换为浏览器可执行配置：
+
+- 统一 `FingerprintConfig`
+- Chromium 启动参数生成
+- Playwright / CDP 所需连接元数据
+
+该层是 Manager 与 Native Runtime 的关键边界。
+
+### 4.5 Automation Bridge
+
+负责为自动化框架暴露统一连接入口，例如：
+
+- ws endpoint
+- remote debugging port
+- 未来的 attach / reconnect 信息
+
+## 5. 关键数据流
+
+### 5.1 应用启动
+1. React App 启动
+2. `loadDesktopOverview()` 检查当前是否运行在 Tauri 环境
+3. Dashboard 展示桥接状态
+
+### 5.2 Profile CRUD
+1. 用户在 `ProfilesPage` 填写表单
+2. Profile 通过 `storage.ts` 归一化
+3. 数据写入本地存储
+4. 页面重载后重新 hydrate
+
+### 5.3 实例启动（当前）
+1. 用户点击 Start
+2. `runtime/manager.ts` 分配调试端口
+3. 检查是否存在 running 状态实例，防止重复启动
+4. 生成 ws endpoint 合同面
+5. 将运行态保存到 `sessionStorage`
+6. UI 展示状态、端口、日志
+
+### 5.4 实例启动（目标）
+1. 用户点击 Start
+2. Runtime Adapter 生成 `LaunchPlan`
+3. Native Runtime 接收 `LaunchPlan`
+4. 启动 Chromium / patched runtime
+5. 返回真实 `processId`、`debugPort`、`wsEndpoint`
+6. Lifecycle Manager 同步 UI 状态
+
+## 6. 领域模型
+
+### BrowserProfile
+- profile 基础身份
+- 代理配置
+- 指纹配置
+- 标签、备注、创建更新时间
+
+### BrowserInstance
+- 实例状态
+- 调试端口
+- wsEndpoint
+- 日志
+- 错误摘要
+
+### FingerprintConfig（planned）
+- userAgent
+- language / locale
+- timezone
+- resolution
+- WebRTC policy
+- 未来扩展：WebGL / Canvas / Audio / fonts 等
+
+### LaunchPlan（planned）
+- adapterId
+- fingerprint config
+- Chromium args
+- 环境变量
+- profile data dir / runtime metadata
+
+## 7. 关键设计决策
+
+### 决策 A：先用前端适配层推进
+原因：
+- 当前本地环境缺少 Rust / cargo 验证条件
+- 先把领域接口跑通，更利于后续替换底层实现
+
+### 决策 B：Manager 不直接依赖 Chromium 启动细节
+原因：
+- 避免 UI 层和浏览器启动参数耦合
+- 后续替换底层实现成本更低
+
+### 决策 C：先稳定 contract，再接真实 runtime
+原因：
+- 可以优先推进测试
+- 更适合开源协作和模块拆分
+
+## 8. 当前技术债
+
+截至 2026-03-13，系统仍有以下技术债：
+
+- `README.md` 仍是 Vite 模板，未更新为项目说明
+- runtime manager 仍是 session-backed mock，不是原生进程管理
+- Playwright endpoint 目前是“合同面”，并非真实连接
+- Dashboard 中 running instances 仍未接真实运行态统计
+- Runtime Adapter 尚未正式落地到代码主线
+
+## 9. 下一步实现顺序
+
+建议按以下顺序继续：
+
+1. 交付 issue `#5`：Runtime Adapter
+2. 将 Lifecycle Manager 与 Runtime Adapter 接通
+3. 接入真实 Chromium / native launcher
+4. 交付 issue `#6`：检测实验室与回归流程
+
+## 10. 相关文档
+
+- `docs/product/mvp-prd.md`
+- `docs/architecture/runtime-contract.md`
+- `docs/plans/2026-03-12-instance-lifecycle.md`
+- `docs/plans/2026-03-12-runtime-adapter.md`

--- a/docs/product/mvp-prd.md
+++ b/docs/product/mvp-prd.md
@@ -1,0 +1,161 @@
+# fingerprint-browser MVP PRD
+
+> Last updated: 2026-03-13
+
+## 1. 产品目标
+
+`fingerprint-browser` 的目标是构建一个可本地运行的开源指纹浏览器 MVP，让用户能够：
+
+- 创建和管理多个隔离的浏览器 profile
+- 为每个 profile 配置独立代理与基础指纹参数
+- 启动、停止、重启浏览器实例并查看运行状态
+- 向 Playwright 暴露可连接的运行时入口
+- 对关键指纹检测站点执行最小可用的回归验证
+
+本阶段优先交付“可开发、可验证、可演进”的基础能力，而不是一次性完成完整商用级浏览器内核改造。
+
+## 2. 目标用户
+
+MVP 面向以下用户：
+
+1. **自动化开发者**：需要为 Playwright / 自动化脚本提供稳定的浏览器实例入口
+2. **多账号运营用户**：需要按 profile 隔离代理、分组、标签与运行状态
+3. **开源协作者**：需要清晰的模块边界，以便后续替换底层 runtime、存储和检测能力
+
+## 3. 产品原则
+
+- **Manager / Runtime 分层**：管理界面与浏览器执行层解耦
+- **契约先行**：先定义 profile、runtime、automation 之间的稳定接口
+- **可测试优先**：前期先用纯前端适配层保证测试可跑，再逐步替换成 Tauri / Rust / Chromium 实现
+- **渐进增强**：先做稳定的控制面，再接入真实浏览器进程与检测实验室
+
+## 4. MVP 范围
+
+### 4.1 In Scope
+
+#### A. Manager App
+- Dashboard / Profiles / Settings 基础页面
+- Tauri 桌面壳与前端桥接占位
+
+#### B. Profile 管理
+- 创建 / 编辑 / 删除 / 复制 profile
+- 分组与标签
+- 独立代理配置（HTTP / SOCKS5）
+- 基础指纹字段存储
+
+#### C. 实例生命周期
+- 启动 / 停止 / 重启实例
+- 调试端口分配
+- 运行状态展示
+- profile lock，防止重复启动
+- 输出 Playwright 连接信息合同面
+
+#### D. Runtime Adapter
+- 将 profile 转换为统一 `FingerprintConfig`
+- 生成 Chromium 启动参数计划
+- 保证 Manager 层不依赖具体浏览器启动实现
+
+#### E. 检测实验室
+- 明确 CreepJS / BrowserLeaks 最小回归流程
+- 记录关键检测维度与人工回归步骤
+
+### 4.2 Out of Scope（当前不做）
+
+- 完整自研 Chromium patch
+- 完整 anti-detect 深度伪装能力
+- 云端 profile 同步
+- 多人协作权限系统
+- 商业化授权、计费、远程控制平台
+
+## 5. 功能需求
+
+### FR-1 Profile 管理
+- 用户可以创建多个 profile
+- 每个 profile 独立保存代理与基础指纹参数
+- profile 数据在应用重启后可恢复
+
+### FR-2 实例生命周期
+- 用户可一键启动 / 停止 / 重启 profile 对应实例
+- UI 需要展示当前运行状态
+- 同一 profile 不允许被重复启动
+- 系统需要分配并展示调试端口
+
+### FR-3 Playwright 桥接
+- 系统需要为实例生成 Playwright 可消费的连接信息
+- 前期允许先暴露“连接合同面”，后期再接真实浏览器连接
+
+### FR-4 Runtime Adapter
+- 系统需要从 profile 推导稳定的指纹配置对象
+- 系统需要生成浏览器启动参数计划
+- 后续替换底层 runtime 时，UI 和 Manager 不应被迫重写
+
+### FR-5 检测验证
+- 至少定义 2 个检测站点
+- 明确手工回归步骤
+- 能记录关键检测维度，支持后续自动化
+
+## 6. 非功能需求
+
+- **本地优先**：MVP 在本地单机可运行
+- **可测试**：核心逻辑需能在 Vitest 中验证
+- **可替换**：存储层、runtime 层、automation 层都需要保留适配接口
+- **可观察**：实例生命周期至少提供状态、端口、日志摘要
+
+## 7. 当前阶段状态（截至 2026-03-13）
+
+### 已有能力
+- Tauri + React 基础壳体已建立
+- Dashboard / Profiles / Settings 基础页面已存在
+- Profile CRUD、分组、标签、独立代理、本地存储已完成第一版
+- 实例生命周期第一阶段切片已合入 `main`
+  - 支持启动 / 停止 / 重启
+  - 支持调试端口分配
+  - 支持 profile lock
+  - UI 可展示运行状态、端口、wsEndpoint 合同面
+
+### 未完成能力
+- 真实 Chromium / Tauri runtime 接入
+- Runtime Adapter 正式落地
+- Playwright 真连接
+- 检测实验室与回归脚本
+
+## 8. 里程碑
+
+### M1：工程骨架
+- 对应 issue `#2`
+- 目标：桌面壳、基础导航、桥接占位
+
+### M2：Profile 管理
+- 对应 issue `#3`
+- 目标：可创建、编辑、复制、删除并持久化 profile
+
+### M3：实例生命周期
+- 对应 issue `#4`
+- 目标：实例启停、状态展示、调试端口和 Playwright 入口合同面
+
+### M4：Runtime Adapter
+- 对应 issue `#5`
+- 目标：定义稳定的指纹配置与启动参数生成逻辑
+
+### M5：检测实验室
+- 对应 issue `#6`
+- 目标：形成最小闭环的检测与回归能力
+
+## 9. MVP 完成标准
+
+MVP 被视为完成，至少需要满足：
+
+- 能创建多个隔离 profile
+- 每个 profile 可独立配置代理和基础指纹参数
+- 能启动实例并看到运行状态
+- 能生成并展示 Playwright 可消费的连接信息
+- 能根据 profile 生成稳定的 runtime 启动计划
+- 至少对 2 个检测站点形成可重复执行的验证流程
+
+## 10. 后续文档
+
+本 PRD 与下列文档配套使用：
+
+- `docs/architecture/system-design.md`
+- `docs/architecture/runtime-contract.md`
+- `docs/plans/2026-03-12-runtime-adapter.md`


### PR DESCRIPTION
## Summary
- add a lightweight MVP PRD describing scope, milestones, in-scope and out-of-scope expectations
- add a system design document that maps the current codebase to the planned manager/runtime/native architecture
- add a runtime contract document that defines the future adapter, launch plan and process handle boundaries

## Notes
- This PR establishes the documentation baseline before continuing issue #5 runtime adapter development.
- It reflects the current implementation state as of 2026-03-13, including the first merged lifecycle slice from issue #4.

## Follow-up
- use these docs as the design source for issue #5 and later native runtime integration