### PR TITLE
feat: add chromium runtime adapter slice

### DIFF
--- a/docs/architecture/runtime-contract.md
+++ b/docs/architecture/runtime-contract.md
@@ -75,6 +75,12 @@ export type RuntimeLaunchPlan = {
   metadata: {
     wsPathHint?: string
     profileDataDir?: string
+    browserVersion?: string
+    proxy?: {
+      server: string
+      username?: string
+      password?: string
+    }
   }
 }
 

--- a/docs/plans/2026-03-12-runtime-adapter.md
+++ b/docs/plans/2026-03-12-runtime-adapter.md
@@ -1,0 +1,245 @@
+# Runtime Adapter Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deliver the first Browser Runtime Adapter slice for issue `#5` so a profile can be transformed into a stable fingerprint contract and Chromium launch plan without coupling the UI to a concrete browser process.
+
+**Architecture:** Extend the profile fingerprint model with normalized defaults for user agent and WebRTC policy, then add a pure runtime adapter module that converts a profile plus runtime context into a serializable Chromium launch plan. Reuse the current session-backed lifecycle flow and surface the adapter output in the UI so the later Tauri/Rust launcher can swap in behind the same contract.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library
+
+### Task 1: Normalize profile fingerprint defaults for runtime adapters
+
+**Files:**
+- Modify: `src/features/profiles/storage.ts`
+- Modify: `src/features/profiles/storage.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it("hydrates legacy stored profiles with runtime fingerprint defaults", () => {
+  const storage = createMemoryStorage({
+    [PROFILE_STORAGE_KEY]: JSON.stringify([
+      {
+        id: "profile-1",
+        name: "Legacy profile",
+        group: "Default",
+        tags: [],
+        notes: "",
+        browserEngine: "Chromium",
+        browserVersion: "stable",
+        proxy: { type: "http", host: "", port: "", username: "", password: "" },
+        fingerprint: {
+          timezone: "UTC",
+          locale: "en-US",
+          geolocationPolicy: "prompt",
+          screen: "1920x1080",
+          memory: "8",
+          hardwareConcurrency: "8",
+        },
+        createdAt: "2026-03-12T00:00:00.000Z",
+        updatedAt: "2026-03-12T00:00:00.000Z",
+      },
+    ]),
+  })
+
+  const [profile] = loadProfiles(storage)
+
+  expect(profile.fingerprint.userAgent).toBe("")
+  expect(profile.fingerprint.webrtcPolicy).toBe("proxy-only")
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/features/profiles/storage.test.ts`
+Expected: FAIL because the loaded profile fingerprint does not include the new runtime adapter defaults yet.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export type WebRtcPolicy = "proxy-only" | "default" | "disabled"
+
+function normalizeFingerprint(fingerprint: Partial<ProfileFingerprint>): ProfileFingerprint {
+  return {
+    ...createEmptyProfileDraft().fingerprint,
+    ...fingerprint,
+  }
+}
+```
+
+Add `userAgent` and `webrtcPolicy` to `ProfileFingerprint`, seed `webrtcPolicy` in `createEmptyProfileDraft()`, keep `userAgent` as an empty override slot, and normalize loaded profiles so old saved data still works. The adapter layer will later resolve the effective Chromium UA when the profile has not set one explicitly.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/features/profiles/storage.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/profiles/storage.ts src/features/profiles/storage.test.ts
+git commit -m "feat: normalize runtime fingerprint defaults"
+```
+
+### Task 2: Add the runtime adapter contract and Chromium launch plan builder
+
+**Files:**
+- Create: `src/features/runtime/adapter.ts`
+- Create: `src/features/runtime/adapter.test.ts`
+- Modify: `src/features/runtime/index.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it("builds a chromium launch plan from a profile and running port", () => {
+  const profile = makeProfile({
+    proxy: { type: "http", host: "127.0.0.1", port: "8899", username: "", password: "" },
+    fingerprint: {
+      ...createEmptyProfileDraft().fingerprint,
+      locale: "en-US",
+      timezone: "America/New_York",
+      screen: "1440x900",
+      webrtcPolicy: "proxy-only",
+    },
+  })
+
+  const plan = chromiumRuntimeAdapter.prepareLaunch({
+    profile,
+    debugPort: 9222,
+  })
+
+  expect(plan.fingerprint.language).toBe("en-US")
+  expect(plan.fingerprint.timezone).toBe("America/New_York")
+  expect(plan.launchArgs).toContain("--remote-debugging-port=9222")
+  expect(plan.launchArgs).toContain("--window-size=1440,900")
+  expect(plan.launchArgs).toContain("--proxy-server=http://127.0.0.1:8899")
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/features/runtime/adapter.test.ts`
+Expected: FAIL because the runtime adapter contract does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export type FingerprintConfig = {
+  userAgent: string
+  language: string
+  timezone: string
+  resolution: { width: number; height: number }
+  webrtcPolicy: WebRtcPolicy
+}
+
+export const chromiumRuntimeAdapter: RuntimeAdapter = {
+  id: "chromium",
+  prepareLaunch({ profile, debugPort }) {
+    return {
+      adapterId: "chromium",
+      fingerprint: buildFingerprintConfig(profile),
+      launchArgs: buildChromiumArgs(profile, debugPort),
+      metadata: {
+        browserVersion: profile.browserVersion,
+        proxy: buildProxyMetadata(profile),
+      },
+    }
+  },
+}
+```
+
+Generate a serializable launch plan with `fingerprint`, `launchArgs`, and lightweight metadata that a later Tauri/Rust runner can execute directly. Also add a resolver so only supported engines receive a Chromium launch plan.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/features/runtime/adapter.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/runtime/adapter.ts src/features/runtime/adapter.test.ts src/features/runtime/index.ts
+git commit -m "feat: add chromium runtime adapter"
+```
+
+### Task 3: Surface adapter output in the Profiles UI
+
+**Files:**
+- Modify: `src/features/profiles/ProfilesPage.tsx`
+- Modify: `src/features/profiles/ProfilesPage.test.tsx`
+- Modify: `src/App.css`
+
+**Step 1: Write the failing test**
+
+```ts
+it("shows the runtime adapter preview and remote debugging arg for a running profile", async () => {
+  saveProfiles([profileA])
+  render(<ProfilesPage />)
+
+  await user.click(screen.getByRole("button", { name: /start profile a/i }))
+
+  expect(screen.getByText(/Adapter: chromium/i)).toBeInTheDocument()
+  expect(screen.getByText(/--remote-debugging-port=9222/i)).toBeInTheDocument()
+  expect(screen.getByText(/--window-size=1920,1080/i)).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/features/profiles/ProfilesPage.test.tsx`
+Expected: FAIL because the page does not render runtime adapter output yet.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+const launchPlan = instance
+  ? chromiumRuntimeAdapter.prepareLaunch({
+      profile,
+      debugPort: instance.debugPort,
+    })
+  : null
+```
+
+Render the adapter name, fingerprint summary, and the full launch argument preview alongside the lifecycle details on each profile card so the WebRTC policy and future adapter flags remain visible.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/features/profiles/ProfilesPage.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/features/profiles/ProfilesPage.tsx src/features/profiles/ProfilesPage.test.tsx src/App.css
+git commit -m "feat: preview runtime launch plans"
+```
+
+### Task 4: Verify and publish issue #5
+
+**Files:**
+- Create: `docs/plans/2026-03-12-runtime-adapter.md`
+
+**Step 1: Run focused adapter tests**
+
+Run: `npm test -- src/features/profiles/storage.test.ts src/features/runtime/adapter.test.ts src/features/profiles/ProfilesPage.test.tsx`
+Expected: PASS
+
+**Step 2: Run the full project tests**
+
+Run: `npm test`
+Expected: PASS
+
+**Step 3: Run static verification**
+
+Run: `npm run lint`
+Expected: PASS
+
+**Step 4: Run the production build**
+
+Run: `npm run build`
+Expected: PASS
+
+**Step 5: Publish**
+
+Create a GitHub branch from `main`, push the adapter files through GitHub MCP, open a PR referencing `#5`, and note that this slice establishes the serializable launch contract that the future native runtime will execute.

--- a/src/App.css
+++ b/src/App.css
@@ -239,6 +239,24 @@ textarea {
   gap: 0.35rem;
 }
 
+.runtime-plan {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  background: rgba(142, 164, 255, 0.08);
+  border: 1px solid rgba(142, 164, 255, 0.16);
+}
+
+.runtime-plan__args {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.runtime-plan__args li {
+  word-break: break-all;
+}
+
 .profile-card__header,
 .profile-card__actions {
   display: flex;

--- a/src/features/profiles/ProfilesPage.test.tsx
+++ b/src/features/profiles/ProfilesPage.test.tsx
@@ -102,6 +102,27 @@ describe("ProfilesPage", () => {
     ).toBeInTheDocument()
   })
 
+  it("shows the runtime adapter preview and remote debugging arg for a running profile", async () => {
+    const user = userEvent.setup()
+    const profileA = createProfileFromDraft({
+      ...createEmptyProfileDraft(),
+      name: "Profile A",
+    })
+
+    saveProfiles([profileA])
+
+    render(<ProfilesPage />)
+
+    await user.click(screen.getByRole("button", { name: /start profile a/i }))
+
+    expect(screen.getByText(/Adapter: chromium/i)).toBeInTheDocument()
+    expect(screen.getByText("--remote-debugging-port=9222")).toBeInTheDocument()
+    expect(screen.getByText("--window-size=1920,1080")).toBeInTheDocument()
+    expect(
+      screen.getByText("--force-webrtc-ip-handling-policy=disable_non_proxied_udp"),
+    ).toBeInTheDocument()
+  })
+
   it("restarts a running profile and frees the lock after stop", async () => {
     const user = userEvent.setup()
     const profileA = createProfileFromDraft({

--- a/src/features/profiles/ProfilesPage.tsx
+++ b/src/features/profiles/ProfilesPage.tsx
@@ -14,6 +14,7 @@ import {
 import {
   findRuntimeInstance,
   loadRuntimeInstances,
+  resolveRuntimeAdapter,
   restartProfileInstance,
   saveRuntimeInstances,
   startProfileInstance,
@@ -238,6 +239,13 @@ export function ProfilesPage() {
           {profiles.map((profile) => {
             const instance = findRuntimeInstance(instances, profile.id)
             const lifecycleStatus = instance?.status ?? "idle"
+            const runtimeAdapter = resolveRuntimeAdapter(profile)
+            const launchPlan = instance
+              ? runtimeAdapter?.prepareLaunch({
+                  profile,
+                  debugPort: instance.debugPort,
+                })
+              : null
 
             return (
               <article className="panel-card profile-card" key={profile.id}>
@@ -263,6 +271,22 @@ export function ProfilesPage() {
                   <p>Playwright endpoint: {instance?.wsEndpoint || "Not connected"}</p>
                   {instance?.logs.at(-1) ? <p>{instance.logs.at(-1)?.message}</p> : null}
                 </div>
+                {launchPlan ? (
+                  <div className="runtime-plan">
+                    <p>Adapter: {launchPlan.adapterId}</p>
+                    <p>
+                      Fingerprint: {launchPlan.fingerprint.language} ·{" "}
+                      {launchPlan.fingerprint.timezone} ·{" "}
+                      {launchPlan.fingerprint.resolution.width}x
+                      {launchPlan.fingerprint.resolution.height}
+                    </p>
+                    <ul className="runtime-plan__args">
+                      {launchPlan.launchArgs.map((arg) => (
+                        <li key={arg}>{arg}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
                 <div className="profile-card__actions">
                   {instance?.status === "running" ? (
                     <>

--- a/src/features/profiles/storage.test.ts
+++ b/src/features/profiles/storage.test.ts
@@ -59,6 +59,8 @@ describe("profile storage", () => {
       fingerprint: {
         timezone: "Asia/Shanghai",
         locale: "zh-CN",
+        userAgent: "",
+        webrtcPolicy: "proxy-only" as const,
         geolocationPolicy: "prompt" as const,
         screen: "1920x1080",
         memory: "8",
@@ -75,5 +77,43 @@ describe("profile storage", () => {
     expect(copy.id).not.toBe(original.id)
     expect(copy.name).toBe("Shop A (copy)")
     expect(copy.proxy).toEqual(original.proxy)
+  })
+
+  it("hydrates legacy profiles with runtime fingerprint defaults", () => {
+    const storage = createMemoryStorage({
+      [PROFILE_STORAGE_KEY]: JSON.stringify([
+        {
+          id: "profile-legacy",
+          name: "Legacy profile",
+          group: "Default",
+          tags: [],
+          notes: "",
+          browserEngine: "Chromium",
+          browserVersion: "stable",
+          proxy: {
+            type: "http",
+            host: "",
+            port: "",
+            username: "",
+            password: "",
+          },
+          fingerprint: {
+            timezone: "UTC",
+            locale: "en-US",
+            geolocationPolicy: "prompt",
+            screen: "1920x1080",
+            memory: "8",
+            hardwareConcurrency: "8",
+          },
+          createdAt: "2026-03-12T00:00:00.000Z",
+          updatedAt: "2026-03-12T00:00:00.000Z",
+        },
+      ]),
+    })
+
+    const loadedFingerprint = loadProfiles(storage)[0].fingerprint as Record<string, string>
+
+    expect(loadedFingerprint.webrtcPolicy).toBe("proxy-only")
+    expect(loadedFingerprint.userAgent).toBe("")
   })
 })

--- a/src/features/profiles/storage.ts
+++ b/src/features/profiles/storage.ts
@@ -2,6 +2,7 @@ export const PROFILE_STORAGE_KEY = "fingerprint-browser.profiles.v1"
 
 export type ProxyType = "http" | "socks5"
 export type GeolocationPolicy = "prompt" | "allow" | "block"
+export type WebRtcPolicy = "default" | "proxy-only" | "disabled"
 
 export type ProfileProxy = {
   type: ProxyType
@@ -14,6 +15,8 @@ export type ProfileProxy = {
 export type ProfileFingerprint = {
   timezone: string
   locale: string
+  userAgent: string
+  webrtcPolicy: WebRtcPolicy
   geolocationPolicy: GeolocationPolicy
   screen: string
   memory: string
@@ -57,6 +60,8 @@ export function createEmptyProfileDraft(): ProfileDraft {
     fingerprint: {
       timezone: "UTC",
       locale: "en-US",
+      userAgent: "",
+      webrtcPolicy: "proxy-only",
       geolocationPolicy: "prompt",
       screen: "1920x1080",
       memory: "8",
@@ -123,7 +128,7 @@ export function loadProfiles(
 
   try {
     const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
+    return Array.isArray(parsed) ? parsed.map(normalizeProfile) : []
   } catch {
     return []
   }
@@ -142,4 +147,18 @@ function createProfileId() {
   }
 
   return `profile-${Math.random().toString(36).slice(2, 10)}`
+}
+
+function normalizeProfile(rawProfile: BrowserProfile): BrowserProfile {
+  return {
+    ...rawProfile,
+    proxy: {
+      ...createEmptyProfileDraft().proxy,
+      ...rawProfile.proxy,
+    },
+    fingerprint: {
+      ...createEmptyProfileDraft().fingerprint,
+      ...rawProfile.fingerprint,
+    },
+  }
 }

--- a/src/features/runtime/adapter.test.ts
+++ b/src/features/runtime/adapter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+import { createEmptyProfileDraft, createProfileFromDraft } from "../profiles"
+import { chromiumRuntimeAdapter, resolveRuntimeAdapter } from "./adapter"
+
+function makeProfile() {
+  return createProfileFromDraft({
+    ...createEmptyProfileDraft(),
+    name: "Profile A",
+    proxy: {
+      type: "http",
+      host: "127.0.0.1",
+      port: "8899",
+      username: "",
+      password: "",
+    },
+    fingerprint: {
+      ...createEmptyProfileDraft().fingerprint,
+      locale: "en-US",
+      timezone: "America/New_York",
+      screen: "1440x900",
+      memory: "16",
+      hardwareConcurrency: "12",
+      webrtcPolicy: "proxy-only",
+    },
+  })
+}
+
+describe("chromium runtime adapter", () => {
+  it("builds a chromium launch plan from a profile and running port", () => {
+    const profile = makeProfile()
+
+    const plan = chromiumRuntimeAdapter.prepareLaunch({
+      profile,
+      debugPort: 9222,
+    })
+
+    expect(plan.adapterId).toBe("chromium")
+    expect(plan.browserEngine).toBe("Chromium")
+    expect(plan.fingerprint.language).toBe("en-US")
+    expect(plan.fingerprint.timezone).toBe("America/New_York")
+    expect(plan.fingerprint.resolution).toEqual({ width: 1440, height: 900 })
+    expect(plan.fingerprint.memory).toBe(16)
+    expect(plan.fingerprint.hardwareConcurrency).toBe(12)
+    expect(plan.launchArgs).toContain("--remote-debugging-port=9222")
+    expect(plan.launchArgs).toContain("--window-size=1440,900")
+    expect(plan.launchArgs).toContain("--lang=en-US")
+    expect(plan.launchArgs).toContain("--proxy-server=http://127.0.0.1:8899")
+    expect(plan.launchArgs).toContain(
+      "--force-webrtc-ip-handling-policy=disable_non_proxied_udp",
+    )
+    expect(plan.metadata.wsPathHint).toBe(`/devtools/browser/${profile.id}`)
+  })
+
+  it("uses browserVersion to derive the chromium user agent and preserves authenticated proxy metadata", () => {
+    const profile = createProfileFromDraft({
+      ...createEmptyProfileDraft(),
+      name: "Beta profile",
+      browserVersion: "beta",
+      proxy: {
+        type: "socks5",
+        host: "proxy.example.com",
+        port: "1080",
+        username: "bot",
+        password: "secret",
+      },
+    })
+
+    const plan = chromiumRuntimeAdapter.prepareLaunch({
+      profile,
+      debugPort: 9333,
+    })
+
+    expect(plan.fingerprint.userAgent).toContain("Chrome/137.0.0.0")
+    expect(plan.metadata.proxy).toEqual({
+      server: "socks5://proxy.example.com:1080",
+      username: "bot",
+      password: "secret",
+    })
+  })
+
+  it("resolves adapters only for supported engines", () => {
+    const chromiumProfile = createProfileFromDraft({
+      ...createEmptyProfileDraft(),
+      name: "Chromium profile",
+      browserEngine: "Chromium",
+    })
+    const firefoxProfile = createProfileFromDraft({
+      ...createEmptyProfileDraft(),
+      name: "Firefox profile",
+      browserEngine: "Firefox",
+    })
+
+    expect(resolveRuntimeAdapter(chromiumProfile)).toBe(chromiumRuntimeAdapter)
+    expect(resolveRuntimeAdapter(firefoxProfile)).toBeNull()
+  })
+})

--- a/src/features/runtime/adapter.ts
+++ b/src/features/runtime/adapter.ts
@@ -1,0 +1,181 @@
+import type { GeolocationPolicy, WebRtcPolicy } from "../profiles/storage"
+import type { BrowserProfile } from "../profiles"
+
+const DEFAULT_RESOLUTION = { width: 1920, height: 1080 }
+const DEFAULT_MEMORY = 8
+const DEFAULT_HARDWARE_CONCURRENCY = 8
+const DEFAULT_CHROMIUM_VERSION = "136.0.0.0"
+const CHROMIUM_VERSION_BY_CHANNEL: Record<string, string> = {
+  stable: "136.0.0.0",
+  beta: "137.0.0.0",
+  dev: "138.0.0.0",
+  canary: "139.0.0.0",
+}
+
+export type FingerprintConfig = {
+  userAgent: string
+  language: string
+  timezone: string
+  resolution: {
+    width: number
+    height: number
+  }
+  memory: number
+  hardwareConcurrency: number
+  geolocationPolicy: GeolocationPolicy
+  webrtcPolicy: WebRtcPolicy
+}
+
+export type RuntimeLaunchRequest = {
+  profile: BrowserProfile
+  debugPort: number
+}
+
+export type RuntimeLaunchPlan = {
+  adapterId: string
+  browserEngine: string
+  launchArgs: string[]
+  env: Record<string, string>
+  fingerprint: FingerprintConfig
+  metadata: {
+    wsPathHint: string
+    browserVersion: string
+    proxy?: {
+      server: string
+      username?: string
+      password?: string
+    }
+  }
+}
+
+export interface RuntimeAdapter {
+  id: string
+  supports(engine: string): boolean
+  prepareLaunch(request: RuntimeLaunchRequest): RuntimeLaunchPlan
+}
+
+export const chromiumRuntimeAdapter: RuntimeAdapter = {
+  id: "chromium",
+  supports(engine) {
+    return engine.toLowerCase().includes("chromium")
+  },
+  prepareLaunch({ profile, debugPort }) {
+    const fingerprint = buildFingerprintConfig(profile)
+
+    return {
+      adapterId: "chromium",
+      browserEngine: profile.browserEngine,
+      launchArgs: buildChromiumLaunchArgs(profile, fingerprint, debugPort),
+      env: {},
+      fingerprint,
+      metadata: {
+        wsPathHint: `/devtools/browser/${profile.id}`,
+        browserVersion: profile.browserVersion,
+        proxy: buildProxyMetadata(profile),
+      },
+    }
+  },
+}
+
+export function resolveRuntimeAdapter(profile: BrowserProfile): RuntimeAdapter | null {
+  return chromiumRuntimeAdapter.supports(profile.browserEngine)
+    ? chromiumRuntimeAdapter
+    : null
+}
+
+export function buildFingerprintConfig(profile: BrowserProfile): FingerprintConfig {
+  return {
+    userAgent: profile.fingerprint.userAgent || buildChromiumUserAgent(profile.browserVersion),
+    language: profile.fingerprint.locale,
+    timezone: profile.fingerprint.timezone,
+    resolution: parseResolution(profile.fingerprint.screen),
+    memory: parseNumericValue(profile.fingerprint.memory, DEFAULT_MEMORY),
+    hardwareConcurrency: parseNumericValue(
+      profile.fingerprint.hardwareConcurrency,
+      DEFAULT_HARDWARE_CONCURRENCY,
+    ),
+    geolocationPolicy: profile.fingerprint.geolocationPolicy,
+    webrtcPolicy: profile.fingerprint.webrtcPolicy,
+  }
+}
+
+function buildChromiumLaunchArgs(
+  profile: BrowserProfile,
+  fingerprint: FingerprintConfig,
+  debugPort: number,
+) {
+  const args = [
+    `--remote-debugging-port=${debugPort}`,
+    `--window-size=${fingerprint.resolution.width},${fingerprint.resolution.height}`,
+    `--lang=${fingerprint.language}`,
+    `--user-agent=${fingerprint.userAgent}`,
+  ]
+
+  if (profile.proxy.host && profile.proxy.port) {
+    args.push(`--proxy-server=${profile.proxy.type}://${profile.proxy.host}:${profile.proxy.port}`)
+  }
+
+  if (fingerprint.webrtcPolicy === "proxy-only") {
+    args.push("--force-webrtc-ip-handling-policy=disable_non_proxied_udp")
+  }
+
+  if (fingerprint.webrtcPolicy === "disabled") {
+    args.push("--disable-webrtc")
+  }
+
+  return args
+}
+
+function buildProxyMetadata(profile: BrowserProfile) {
+  if (!profile.proxy.host || !profile.proxy.port) {
+    return undefined
+  }
+
+  return {
+    server: `${profile.proxy.type}://${profile.proxy.host}:${profile.proxy.port}`,
+    username: profile.proxy.username || undefined,
+    password: profile.proxy.password || undefined,
+  }
+}
+
+function parseResolution(screen: string) {
+  const [widthText, heightText] = screen.split("x")
+  const width = Number.parseInt(widthText ?? "", 10)
+  const height = Number.parseInt(heightText ?? "", 10)
+
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return DEFAULT_RESOLUTION
+  }
+
+  return { width, height }
+}
+
+function parseNumericValue(value: string, fallback: number) {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function buildChromiumUserAgent(browserVersion: string) {
+  const chromeVersion = resolveChromiumVersion(browserVersion)
+
+  return `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`
+}
+
+function resolveChromiumVersion(browserVersion: string) {
+  const normalizedVersion = browserVersion.trim().toLowerCase()
+
+  if (CHROMIUM_VERSION_BY_CHANNEL[normalizedVersion]) {
+    return CHROMIUM_VERSION_BY_CHANNEL[normalizedVersion]
+  }
+
+  if (/^\d+(\.\d+){0,3}$/.test(normalizedVersion)) {
+    const segments = normalizedVersion.split(".")
+    while (segments.length < 4) {
+      segments.push("0")
+    }
+
+    return segments.join(".")
+  }
+
+  return DEFAULT_CHROMIUM_VERSION
+}

--- a/src/features/runtime/index.ts
+++ b/src/features/runtime/index.ts
@@ -11,6 +11,16 @@ export const runtimeDiagnostics = [
 ]
 
 export {
+  buildFingerprintConfig,
+  chromiumRuntimeAdapter,
+  resolveRuntimeAdapter,
+  type FingerprintConfig,
+  type RuntimeAdapter,
+  type RuntimeLaunchPlan,
+  type RuntimeLaunchRequest,
+} from "./adapter"
+
+export {
   RUNTIME_STORAGE_KEY,
   findRuntimeInstance,
   loadRuntimeInstances,


### PR DESCRIPTION
## Summary
- add a serializable Chromium runtime adapter and fingerprint contract for profile-to-launch-plan conversion
- preserve browserVersion and authenticated proxy metadata in runtime launch plans
- preview runtime adapter output and full launch args in the Profiles UI

## Verification
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`

## Notes
- this slice keeps the current session-backed lifecycle flow and prepares the contract boundary for a later native Tauri/Rust launcher

Closes #5